### PR TITLE
Display "sitelen sitelen" in /about/lipu

### DIFF
--- a/css.css
+++ b/css.css
@@ -158,6 +158,7 @@ hr {
 	justify-content: center;
 	align-items: center;
     filter: invert(100%);
+    color: var(--bg-color);
     height: 50px;
     width: 50px;
     margin: auto;


### PR DESCRIPTION
The text of `<div class="sitelensitelen">sitelen sitelen</div>` in `about/lipu/index.html` must be black before the inversion filter to appear on screen.