### PR TITLE
Add detailed information from jasima, other QoL improvements

### DIFF
--- a/about/lipu/index.html
+++ b/about/lipu/index.html
@@ -1,38 +1,85 @@
 ﻿<!DOCTYPE html>
 <html>
-	<head>
-		<title>lipu Linku - about - lipu Linku</title>
-		<base href="../../">
-		<link rel="stylesheet" type="text/css" href="css.css" />
-		<link rel="stylesheet" type="text/css" href="checkbox.css" />
-		<link rel="shortcut icon" href="icon.png">
-		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto%20Serif">
-		<script type="text/javascript" src="scripts.js"></script>
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	</head>
-	<body>
-		<div class="page_width_limiter">
-			<a class="navlink" href="about">Go back</a>
-			<h1>lipu Linku (the <a href="https://lipu-linku.github.io">website</a>)</h1>
-			<p>The <a href="https://lipu-linku.github.io">website</a> is for browsing the dictionary in a nicely presented / filtered way.</p>
-			<p>The data is loaded from the <a href="about/jasima">mirror / database</a>.</p>
-			<p>You may choose the language you want definitions to use, and filter by the words' appearances in books.</p>
-			<p>Entries use the following template:</p>
-			<div class="entry" style="border: solid var(--shade-color) 2px; padding: 5px">
-				<div class="sourcelanguage">Source language</div>
-				<div class="creator">Creator</div>
-				<div class="etymology">Etymology</div>
-				<div class="coined">Date (era) coined</div>
-				<div class="sitelenpona" style="font-family: inherit; font-size: inherit">sitelen pona</div>
-				<div class="book">book appearances</div>
-				<div class="sitelensitelen">sitelen sitelen</div>
-				<div class="recognition">recognition as a percentage (plus date)</div>
-				<div class="word">toki pona word</div>
-				<div class="definition">Definitions of the word</div>
-				<div class="seealso">{see other toki pona words}</div>
-				<div class="kudata">A free sample of ku data</div>
-				<div class="commentary">Additional commentary, which does not belong in one of the predetermined categories, but is nevertheless important for understanding the specifics of the word</div>
-			</div>
-		</div>
-	</body>
+  <head>
+    <title>lipu Linku - about - lipu Linku</title>
+    <base href="../../" />
+    <link rel="stylesheet" type="text/css" href="css.css" />
+    <link rel="stylesheet" type="text/css" href="checkbox.css" />
+    <link rel="shortcut icon" href="icon.png" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Noto%20Serif"
+    />
+    <script type="text/javascript" src="scripts.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+  <body>
+    <div class="page_width_limiter">
+      <a class="navlink" href="about">Go back</a>
+      <h1>
+        lipu Linku (the <a href="https://lipu-linku.github.io">website</a>)
+      </h1>
+      <p>
+        The <a href="https://lipu-linku.github.io">website</a> is for browsing
+        the dictionary in a nicely presented / filtered way.
+      </p>
+      <p>
+        The data is loaded from the
+        <a href="about/jasima">mirror / database</a>.
+      </p>
+      <p>
+        You may choose the language you want definitions to use, and filter by
+        the words' appearances in books.
+      </p>
+      <p>Entries use the following template:</p>
+      <div
+        class="entry"
+        style="border: solid var(--shade-color) 2px; padding: 5px"
+      >
+        <div class="sourcelanguage">Source language</div>
+        <div class="creator">Creator</div>
+        <div class="etymology">Etymology</div>
+        <div class="coined">Date (era) coined</div>
+        <div
+          class="sitelenpona"
+          style="font-family: inherit; font-size: inherit"
+        >
+          sitelen pona
+        </div>
+        <div class="book">book appearances</div>
+        <div class="sitelensitelen">sitelen sitelen</div>
+        <div class="recognition">recognition as a percentage (plus date)</div>
+        <div class="word">toki pona word</div>
+        <div class="definition">Definitions of the word</div>
+        <div class="seealso">{see other toki pona words}</div>
+
+        <details open="">
+          <summary>more info</summary>
+          <div class="details">
+            <div class="commentary">
+              Commentary, which does not fit in another category, but is
+              important for understanding the specifics of the word
+            </div>
+            <div class="kudata">A free sample of ku data</div>
+            <div class="sitelenponaetymology">
+              Etymology of the sitelen pona
+            </div>
+            <div class="lukapona">luka pona</div>
+            <div class="sitelenemosi" style="font-size: 100%">
+              sitelen emosi
+            </div>
+            <a
+              class="audio_kalaasi"
+              href="http://antetokipona.infinityfreeapp.com/kalama/kalaasi/ala.mp3"
+              >kala asi audio</a
+            ><a
+              class="audio_janlakuse"
+              href="http://antetokipona.infinityfreeapp.com/kalama/jlakuse/ala.mp3"
+              >jan lakuse audio</a
+            >
+          </div>
+        </details>
+      </div>
+    </div>
+  </body>
 </html>

--- a/css.css
+++ b/css.css
@@ -20,7 +20,7 @@ body {
 	--link-color: #008472;
 	--shade-color: #999999;
 }
-.light_mode {
+.lightmode {
 	--bg-color: #ffffff;
 	--txt-color: #000000;
 	--highlight-color: #ffab40;
@@ -83,8 +83,25 @@ h1, h2 {
 		'sitelenpona word word word sitelensitelen'
 		'sitelenpona definition definition definition sitelensitelen'
 		'. seealso seealso seealso .'
-		'kudata kudata kudata kudata kudata'
-		'commentary commentary commentary commentary commentary';
+        'details details details details details';
+}
+details {
+    margin: 5px;
+    border: 1px;
+	border-color: var(--shade-color);
+    grid-area: details;
+}
+.details {
+    display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 1fr);
+	grid-column-gap: 10px;
+	grid-template-areas:
+        'emosi . . lukapona lukapona'
+        'emosi . . lukapona lukapona'
+		'spetymology spetymology . commentary commentary'
+		'spetymology spetymology . commentary commentary'
+        'kudata kudata kudata kudata kudata '
+        'audio_kalaasi audio_kalaasi . audio_janlakuse audio_janlakuse'
 }
 hr {
 	border-color: var(--shade-color);
@@ -138,8 +155,27 @@ hr {
 	grid-area: kudata;
 	color: var(--shade-color);
 }
-.kudata { display: none }
-.display_ku_data .kudata { display: block }
+.lukapona {
+    grid-area: lukapona;
+	color: var(--shade-color);
+}
+summary {
+	color: var(--shade-color);
+}
+.audio_janlakuse {
+    grid-area: audio_janlakuse
+}
+.audio_kalaasi {
+    grid-area: audio_kalaasi;
+}
+.sitelenemosi {
+    font-size: 300%;
+    grid-area: emosi
+}
+.sitelenponaetymology {
+    grid-area: spetymology;
+	color: var(--shade-color);
+}
 .commentary {
 	grid-area: commentary;
 	color: var(--shade-color);
@@ -163,7 +199,7 @@ hr {
     width: 50px;
     margin: auto;
 }
-.light_mode .sitelensitelen {
+.lightmode .sitelensitelen {
     filter: none;
 }
 .shaded {
@@ -176,6 +212,9 @@ hr {
 	display: inline-grid;
 }
 #search_selector {
+	display: inline-grid;
+}
+#settings_selector {
 	display: inline-grid;
 }
 #normal_mode_button {

--- a/css.css
+++ b/css.css
@@ -157,7 +157,6 @@ hr {
 }
 .lukapona {
     grid-area: lukapona;
-	color: var(--shade-color);
 }
 summary {
 	color: var(--shade-color);
@@ -169,7 +168,7 @@ summary {
     grid-area: audio_kalaasi;
 }
 .sitelenemosi {
-    font-size: 300%;
+    font-size: 200%;
     grid-area: emosi
 }
 .sitelenponaetymology {

--- a/index.html
+++ b/index.html
@@ -17,22 +17,14 @@
                 </select>
             </div>
             <div id="checkbox_container">
-                <div id="book_selector">
-                    <label class="container">light mode
-                        <input type="checkbox" id="checkbox_light_mode">
-                        <span class="checkmark"></span>
-                    </label>
-                    <label class="container">show ku data
-                        <input type="checkbox" id="checkbox_ku_data">
-                        <span class="checkmark"></span>
-                    </label>
-                </div>
-                <div id="search_selector"></div>
+                <div id="book_selector"> </div>
+                <div id="settings_selector"> </div>
+                <div id="search_selector"> </div> <!-- MOVE NEXT TO SEARCH BAR -->
             </div>
             <div>
                 <input id="searchbar" placeholder="nimi" onkeyup="search_changed(this)" autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false"></input>
             </div>
-			<button id="normal_mode_button" onclick="normal_mode()">More words</button>
+			<button id="normal_mode_button" onclick="normal_mode()">Back to dictionary</button>
 			<div id="dictionary">
 			</div>
 		</div>

--- a/scripts.js
+++ b/scripts.js
@@ -119,10 +119,9 @@ function build_word(id, word, force = false) {
             details_div.appendChild(build_element("div", word["sitelen_pona_etymology"], "sitelenponaetymology", word["sitelen_pona_etymology"]))
         }
 
-        // NOTE: not currently working; third party links to the site won't load the image
+        // NOTE: maybe embed later, instead of linking?
         if (word["luka_pona"]) {
-            details_div.appendChild(build_element("div", "luka pona coming later!", "lukapona"))
-            // details_div.appendChild(build_element("img", "", "lukapona", word["luka_pona"]["gif"]))
+            details_div.appendChild(build_element("a", "view luka pona", "lukapona", word["luka_pona"]["gif"]))
         }
         if (word["sitelen_emosi"]) {
             details_div.appendChild(build_element("div", word["sitelen_emosi"], "sitelenemosi"))

--- a/scripts.js
+++ b/scripts.js
@@ -129,8 +129,8 @@ function build_word(id, word, force = false) {
         }
 
         if (word["audio"]) {
-            audio_kalaasi = build_element("a", "kala asi speaks", "audio_kalaasi", word["audio"]["kala_asi"])
-            audio_janlakuse = build_element("a", "jan lakuse speaks", "audio_janlakuse", word["audio"]["jan_lakuse"])
+            audio_kalaasi = build_element("a", "kala Asi speaks", "audio_kalaasi", word["audio"]["kala_asi"])
+            audio_janlakuse = build_element("a", "jan Lakuse speaks", "audio_janlakuse", word["audio"]["jan_lakuse"])
             // audio_kalaasi = build_element("audio", "", "audio_kalaasi", word["audio"]["kala_asi"])
             // audio_janlakuse = build_element("audio", "", "audio_janlakuse", word["audio"]["jan_lakuse"])
             // audio_kalaasi.controls = true

--- a/scripts.js
+++ b/scripts.js
@@ -1,6 +1,6 @@
-String.prototype.fuzzy = function (s) {
+String.prototype.fuzzy = function(s) {
     var i = 0, n = -1, l;
-    for (; l = s[i++] ;) if (!~(n = this.indexOf(l, n + 1))) return false;
+    for (; l = s[i++];) if (!~(n = this.indexOf(l, n + 1))) return false;
     return true;
 };
 
@@ -31,13 +31,12 @@ function build_element(tag, text, classname = null, src = null) {
 
 function fill_dictionary() {
     dictionary = document.getElementById("dictionary")
-    for (var id in data) {
-        if (!show_word) {
+    if (show_word) {
+        dictionary.appendChild(build_word(show_word, data[show_word], true))
+        return;
+    } else {
+        for (var id in data) {
             if (localStorage.getItem(books_to_checkboxes[data[id]["book"]]) === "true") {
-                dictionary.appendChild(build_word(id, data[id]))
-            }
-        } else {
-            if (show_word == id) {
                 dictionary.appendChild(build_word(id, data[id]))
             }
         }
@@ -51,13 +50,13 @@ function clear_dictionary() {
     }
 }
 
-function build_word(id, word) {
+function build_word(id, word, force = false) {
     var word_container = document.createElement("div")
     word_container.id = id
     word_container.className = "entry"
-    
+
     word_container.appendChild(document.createElement("hr"))
-    
+
     if (word["source_language"]) {
         word_container.appendChild(build_element("div", word["source_language"], "sourcelanguage"))
     }
@@ -84,13 +83,13 @@ function build_word(id, word) {
             break
         }
     }
-    
+
     if (word["sitelen_pona"]) {
         word_container.appendChild(build_element("div", word["sitelen_pona"], "sitelenpona"))
     }
     word_container.appendChild(build_element("div", word["word"], "word"))
     // The switch statement is temporary!
-    
+
     definition = word["def"][localStorage.getItem("selected_language")]
     if (definition) {
         word_container.appendChild(build_element("div", definition, "definition"))
@@ -104,7 +103,7 @@ function build_word(id, word) {
         word_container.appendChild(build_element("div", "{see " + word["see_also"] + "}", "seealso"))
     }
     var details = document.getElementById("checkbox_detailed").checked
-    if (details === true) {
+    if (details === true | force === true) {
         var details_div = build_element("div", "", "details")
         var details_container = build_element("details", "")
         details_container.appendChild(build_element("summary", "more info"))
@@ -142,13 +141,13 @@ function build_word(id, word) {
 
         // TODO: hide or show by default?
         details_container.open = true;
-        if (details_div.childNodes.length > 1) { 
+        if (details_div.childNodes.length > 1) {
             // only append if non-empty; # text is present tho
             word_container.appendChild(details_container)
-        }  
+        }
     }
-    
-    
+
+
     return word_container
 }
 
@@ -162,7 +161,7 @@ function main() {
     checkbox_select_default()
     // Generate words
     fill_dictionary()
-    
+
     checkbox_lightmode = document.getElementById("checkbox_lightmode")
     checkbox_lightmode.checked = localStorage.checkbox_lightmode === 'true';
     if (checkbox_lightmode.checked) {
@@ -170,7 +169,7 @@ function main() {
     }
     checkbox_lightmode.addEventListener('change', function(e) {
         localStorage.checkbox_lightmode = e.target.checked;
-        if (e.target.checked) {document.body.classList.add('lightmode');}
+        if (e.target.checked) { document.body.classList.add('lightmode'); }
         else document.body.classList.remove('lightmode')
     });
 }
@@ -185,7 +184,7 @@ function language_select_default() {
     if (!localStorage.getItem("selected_language")) {
         localStorage.setItem("selected_language", "en")
     }
-    
+
     language_selector = document.getElementById("language_selector")
     for (var id in languages) {
         option = build_select_option(id, languages[id]["name_endonym"])
@@ -219,7 +218,7 @@ function build_checkbox_option(name, value) {
     container = document.createElement("label")
     container.className = "container"
     container.appendChild(build_text(checkbox_labels[name]))
-    
+
     checkbox = document.createElement("input")
     checkbox.type = "checkbox"
     checkbox.id = name
@@ -227,7 +226,7 @@ function build_checkbox_option(name, value) {
     checkbox.onchange = checkbox_changed
     checkbox.autocomplete = 'off' // prevent refresh refill; only localStorage
     container.appendChild(checkbox)
-    
+
     checkmark = document.createElement("span")
     checkmark.className = "checkmark"
     container.appendChild(checkmark)
@@ -325,7 +324,7 @@ const selector_map = {
     "settings_selector": [
         "checkbox_lightmode",
         "checkbox_detailed",
-        "checkbox_definitions",  
+        "checkbox_definitions",
         // TODO: move 'definitions' to search selector
         // whenever the page looks prettier
     ]


### PR DESCRIPTION
- Fuzzy search no longer active in definition search, only word search
  - More accurate searching in both modes
- Fuzzy search removed as an option; always active in word search, never
  active in definition search
- Newly added detailed view mode, stashing many previously unshown
  elements under a details tag (open by default, when enabled)
- ku data now in detailed view mode
- ku data option merged into detailed view
- commentary now in detailed view mode
- definition search removed from local storage; if you leave the page
  and come back hours later, you generally want word search
- audio links, sitelen emosi, sitelen pona etymology, luka pona TODO
  added to detailed view
- "More words" button changed to "Back to dictionary" in single word
  mode
- Detailed view added to single word mode

---

- luka pona host is broken, cannot embed yet
- audio tags linked, NOT embedded. Too slow to embed.
  - Can we embed on demand?
- detailed view NOT included in local storage