### PR TITLE
Nearness-sorted search with fuzzy match filtering

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -377,15 +377,7 @@ function single_word_mode() {
   document.getElementById("normal_mode_button").style.display = "initial";
 }
 function normal_mode() {
-  show_word = null;
-  clear_dictionary();
-  fill_dictionary();
-  for (let checkbox_div of Object.keys(selector_map)) {
-    document.getElementById(checkbox_div).style.display = "";
-  }
-  document.getElementById("searchbar").style.display = "";
-  document.getElementById("normal_mode_button").style.display = "none";
-  window.location.search = ""; // remove query from url
+  window.location.search = ""; // remove query and refresh
 }
 
 const bundle_url = "https://lipu-linku.github.io/jasima/data.json";

--- a/scripts.js
+++ b/scripts.js
@@ -31,23 +31,38 @@ function build_element(tag, text, classname = null, src = null) {
   return div;
 }
 
+function set_visibility(elem, display) {
+  if (elem) {
+    elem.style.display = display;
+  }
+}
+
+function update_visibility() {
+  dictionary = document.getElementById("dictionary");
+  for (var id in data) {
+    let word = dictionary.querySelector("#" + id);
+    localStorage.getItem(usages_to_checkboxes[data[id]["usage_category"]]) ===
+    "true"
+      ? set_visibility(word, "")
+      : set_visibility(word, "none");
+
+    document.getElementById("checkbox_detailed").checked === true
+      ? set_visibility(word.querySelector("details"), "")
+      : set_visibility(word.querySelector("details"), "none");
+  }
+}
+
 function fill_dictionary() {
   dictionary = document.getElementById("dictionary");
   if (show_word) {
-    dictionary.appendChild(build_word(show_word, data[show_word], true));
+    dictionary.appendChild(build_word(show_word, data[show_word]));
     return;
   } else {
     for (var id in data) {
-      if (
-        localStorage.getItem(
-          usages_to_checkboxes[data[id]["usage_category"]]
-        ) === "true"
-      ) {
-        dictionary.appendChild(build_word(id, data[id]));
-      }
+      dictionary.appendChild(build_word(id, data[id]));
     }
+    search_changed(document.getElementById("searchbar"));
   }
-  search_changed(document.getElementById("searchbar"));
 }
 function clear_dictionary() {
   dictionary = document.getElementById("dictionary");
@@ -56,7 +71,7 @@ function clear_dictionary() {
   }
 }
 
-function build_word(id, word, force = false) {
+function build_word(id, word) {
   var word_container = document.createElement("div");
   word_container.id = id;
   word_container.className = "entry";
@@ -79,7 +94,7 @@ function build_word(id, word, force = false) {
       build_element("div", word["etymology"], "etymology")
     );
   }
-  coined = [
+  let coined = [
     word["coined_year"] ? word["coined_year"] + " " : "",
     word["coined_era"] ? "(" + word["coined_era"] + ")" : "",
   ].join(" ");
@@ -143,76 +158,68 @@ function build_word(id, word, force = false) {
     see_also_div.innerHTML += "}";
     word_container.appendChild(see_also_div);
   }
-  var details = document.getElementById("checkbox_detailed").checked;
-  if ((details === true) | (force === true)) {
-    var details_div = build_element("div", "", "details");
-    var details_container = build_element("details", "");
-    details_container.appendChild(build_element("summary", "more info"));
-    details_container.appendChild(details_div);
+  let details_div = build_element("div", "", "details");
+  let details_container = build_element("details", "");
+  details_container.appendChild(build_element("summary", "more info"));
+  details_container.appendChild(details_div);
 
-    if (word["commentary"]) {
-      details_div.appendChild(
-        build_element("div", word["commentary"], "commentary")
-      );
-    }
-    if (word["ku_data"]) {
-      details_div.appendChild(build_element("div", word["ku_data"], "kudata"));
-    }
-    if (word["sitelen_pona_etymology"]) {
-      details_div.appendChild(
-        build_element(
-          "div",
-          word["sitelen_pona_etymology"],
-          "sitelenponaetymology",
-          word["sitelen_pona_etymology"]
-        )
-      );
-    }
+  if (word["commentary"]) {
+    details_div.appendChild(
+      build_element("div", word["commentary"], "commentary")
+    );
+  }
+  if (word["ku_data"]) {
+    details_div.appendChild(build_element("div", word["ku_data"], "kudata"));
+  }
+  if (word["sitelen_pona_etymology"]) {
+    details_div.appendChild(
+      build_element(
+        "div",
+        word["sitelen_pona_etymology"],
+        "sitelenponaetymology",
+        word["sitelen_pona_etymology"]
+      )
+    );
+  }
 
-    // NOTE: maybe embed later, instead of linking?
-    if (word["luka_pona"]) {
-      details_div.appendChild(
-        build_element(
-          "a",
-          "view luka pona",
-          "lukapona",
-          word["luka_pona"]["gif"]
-        )
-      );
-    }
-    // if (word["sitelen_emosi"]) {
-    //   details_div.appendChild(
-    //     build_element("div", word["sitelen_emosi"], "sitelenemosi")
-    //   );
-    // }
+  // NOTE: maybe embed later, instead of linking?
+  if (word["luka_pona"]) {
+    details_div.appendChild(
+      build_element("a", "view luka pona", "lukapona", word["luka_pona"]["gif"])
+    );
+  }
+  // if (word["sitelen_emosi"]) {
+  //   details_div.appendChild(
+  //     build_element("div", word["sitelen_emosi"], "sitelenemosi")
+  //   );
+  // }
 
-    if (word["audio"]) {
-      audio_kalaasi = build_element(
-        "a",
-        "kala Asi speaks",
-        "audio_kalaasi",
-        word["audio"]["kala_asi"]
-      );
-      audio_janlakuse = build_element(
-        "a",
-        "jan Lakuse speaks",
-        "audio_janlakuse",
-        word["audio"]["jan_lakuse"]
-      );
-      // audio_kalaasi = build_element("audio", "", "audio_kalaasi", word["audio"]["kala_asi"])
-      // audio_janlakuse = build_element("audio", "", "audio_janlakuse", word["audio"]["jan_lakuse"])
-      // audio_kalaasi.controls = true
-      // audio_janlakuse.controls = true
-      details_div.appendChild(audio_kalaasi);
-      details_div.appendChild(audio_janlakuse);
-    }
+  if (word["audio"]) {
+    let audio_kalaasi = build_element(
+      "a",
+      "kala Asi speaks",
+      "audio_kalaasi",
+      word["audio"]["kala_asi"]
+    );
+    let audio_janlakuse = build_element(
+      "a",
+      "jan Lakuse speaks",
+      "audio_janlakuse",
+      word["audio"]["jan_lakuse"]
+    );
+    // audio_kalaasi = build_element("audio", "", "audio_kalaasi", word["audio"]["kala_asi"])
+    // audio_janlakuse = build_element("audio", "", "audio_janlakuse", word["audio"]["jan_lakuse"])
+    // audio_kalaasi.controls = true
+    // audio_janlakuse.controls = true
+    details_div.appendChild(audio_kalaasi);
+    details_div.appendChild(audio_janlakuse);
+  }
 
-    // TODO: hide or show by default?
-    details_container.open = true;
-    if (details_div.childNodes.length > 1) {
-      // only append if non-empty; # text is present tho
-      word_container.appendChild(details_container);
-    }
+  // TODO: hide or show by default?
+  details_container.open = true;
+  if (details_div.childNodes.length > 1) {
+    // only append if non-empty; # text is present tho
+    word_container.appendChild(details_container);
   }
 
   return word_container;
@@ -228,6 +235,7 @@ function main() {
   checkbox_select_default();
   // Generate words
   fill_dictionary();
+  update_visibility();
 
   checkbox_lightmode = document.getElementById("checkbox_lightmode");
   checkbox_lightmode.checked = localStorage.checkbox_lightmode === "true";
@@ -267,6 +275,7 @@ function language_select_changed(select_node) {
   localStorage.setItem("selected_language", selected_option.value);
   clear_dictionary();
   fill_dictionary();
+  update_visibility();
 }
 
 function checkbox_select_default() {
@@ -320,8 +329,7 @@ function checkbox_changed() {
       localStorage.setItem(checkbox, is_checked);
     }
   }
-  clear_dictionary();
-  fill_dictionary();
+  update_visibility();
 }
 
 function str_matches(str1, str2) {
@@ -351,11 +359,11 @@ function search_changed(searchbar) {
       match = entries[i].querySelector(".definition").textContent;
     }
 
-    if (str_matches(match, search)) {
-      entries[i].style.display = "";
-    } else {
-      entries[i].style.display = "none";
-    }
+    // if (str_matches(match, search)) {
+    //   entries[i].style.display = "";
+    // } else {
+    //   entries[i].style.display = "none";
+    // }
   }
 }
 

--- a/scripts.js
+++ b/scripts.js
@@ -216,7 +216,6 @@ function build_word(id, word) {
     details_div.appendChild(audio_janlakuse);
   }
 
-  // TODO: hide or show by default?
   details_container.open = true;
   if (details_div.childNodes.length > 1) {
     // only append if non-empty; # text is present tho
@@ -236,6 +235,7 @@ function main() {
   checkbox_select_default();
   // Generate words
   fill_dictionary();
+  // show based on settings
   update_visibility();
 
   checkbox_lightmode = document.getElementById("checkbox_lightmode");
@@ -328,10 +328,6 @@ function checkbox_changed() {
 }
 
 function str_matches(str1, str2) {
-  // ignore_diacritics = document.getElementById("checkbox_ignore_diacritics").checked
-  // if (ignore_diacritics) { }
-  // ignore_case = document.getElementById("checkbox_ignore_case").checked
-  // if (ignore_case) { }
   str1 = str1.normalize("NFD").replace(/\p{Diacritic}/gu, "");
   str2 = str2.normalize("NFD").replace(/\p{Diacritic}/gu, "");
   str1 = str1.toLowerCase();
@@ -356,6 +352,7 @@ function search_changed(searchbar) {
       match = entries[i].querySelector(".definition").textContent;
     }
 
+    // TODO
     // if (str_matches(match, search)) {
     //   entries[i].style.display = "";
     // } else {

--- a/scripts.js
+++ b/scripts.js
@@ -1,3 +1,4 @@
+"use strict";
 String.prototype.fuzzy = function (s) {
   var i = 0,
     n = -1,
@@ -109,11 +110,11 @@ function build_word(id, word) {
     for (var date in Object.fromEntries(
       Object.entries(word["recognition"]).reverse()
     )) {
-      percent = word["recognition"][date];
-      usage_category = word["usage_category"]
+      let percent = word["recognition"][date];
+      let usage_category = word["usage_category"]
         ? word["usage_category"]
         : "unknown";
-      recognition = `${usage_category} (${percent}% in ${date})`;
+      let recognition = `${usage_category} (${percent}% in ${date})`;
       word_container.appendChild(
         build_element("div", recognition, "recognition")
       );
@@ -129,7 +130,7 @@ function build_word(id, word) {
   word_container.appendChild(build_element("div", word["word"], "word"));
   // The switch statement is temporary!
 
-  definition = word["def"][localStorage.getItem("selected_language")];
+  let definition = word["def"][localStorage.getItem("selected_language")];
   if (definition) {
     word_container.appendChild(build_element("div", definition, "definition"));
   } else {
@@ -146,7 +147,7 @@ function build_word(id, word) {
     let see_also_div = build_element("div", "{see ", "seealso");
     let see_alsos = word["see_also"].split(", ");
     for (let i = 0; i < see_alsos.length; i++) {
-      seen = see_alsos[i];
+      let seen = see_alsos[i];
       see_also_div.appendChild(
         build_element("a", seen, "seealsolink", "#" + seen)
       );
@@ -251,7 +252,7 @@ function main() {
 }
 
 function build_select_option(option_value, text) {
-  option_node = document.createElement("option");
+  let option_node = document.createElement("option");
   option_node.value = option_value;
   option_node.appendChild(build_text(text));
   return option_node;
@@ -262,8 +263,8 @@ function language_select_default() {
   }
 
   language_selector = document.getElementById("language_selector");
-  for (var id in languages) {
-    option = build_select_option(id, languages[id]["name_endonym"]);
+  for (let id in languages) {
+    let option = build_select_option(id, languages[id]["name_endonym"]);
     if (id == localStorage.getItem("selected_language")) {
       option.selected = true;
     }
@@ -285,7 +286,7 @@ function checkbox_select_default() {
     }
   }
   for (let [checkbox_div, checkboxes] of Object.entries(selector_map)) {
-    div = document.getElementById(checkbox_div);
+    let div = document.getElementById(checkbox_div);
     for (const checkbox of checkboxes) {
       div.appendChild(
         build_checkbox_option(
@@ -297,11 +298,11 @@ function checkbox_select_default() {
   }
 }
 function build_checkbox_option(name, value) {
-  container = document.createElement("label");
+  let container = document.createElement("label");
   container.className = "container";
   container.appendChild(build_text(checkbox_labels[name]));
 
-  checkbox = document.createElement("input");
+  let checkbox = document.createElement("input");
   checkbox.type = "checkbox";
   checkbox.id = name;
   checkbox.checked = value;
@@ -309,16 +310,10 @@ function build_checkbox_option(name, value) {
   checkbox.autocomplete = "off"; // prevent refresh refill; only localStorage
   container.appendChild(checkbox);
 
-  checkmark = document.createElement("span");
+  let checkmark = document.createElement("span");
   checkmark.className = "checkmark";
   container.appendChild(checkmark);
   return container;
-  /*checkbox = document.createElement("input")
-    checkbox.type = "checkbox"
-    checkbox.id = name
-    checkbox.checked = value
-    checkbox.onchange = checkbox_changed
-    return checkbox*/
 }
 function checkbox_changed() {
   for (let checkbox of Object.keys(checkbox_labels)) {
@@ -341,7 +336,9 @@ function str_matches(str1, str2) {
   str2 = str2.normalize("NFD").replace(/\p{Diacritic}/gu, "");
   str1 = str1.toLowerCase();
   str2 = str2.toLowerCase();
-  definition_search = document.getElementById("checkbox_definitions").checked;
+  let definition_search = document.getElementById(
+    "checkbox_definitions"
+  ).checked;
   if (definition_search) {
     // INTENDED: don't fuzzy search defs, it sucks
     return str1.includes(str2);
@@ -350,10 +347,10 @@ function str_matches(str1, str2) {
 }
 
 function search_changed(searchbar) {
-  search = searchbar.value.trim();
-  search_defs = document.getElementById("checkbox_definitions").checked;
-  entries = document.getElementsByClassName("entry");
-  for (var i = 0; i < entries.length; i++) {
+  let search = searchbar.value.trim();
+  let search_defs = document.getElementById("checkbox_definitions").checked;
+  let entries = document.getElementsByClassName("entry");
+  for (let i = 0; i < entries.length; i++) {
     var match = entries[i].id;
     if (search_defs) {
       match = entries[i].querySelector(".definition").textContent;


### PR DESCRIPTION
I've separated out the logic for visibility into its own group of functions. `search_changed` calls the main `update_visibility` function (since update_visibility checks fuzzy match against search term), but itself is only responsible for sorting the (visible) terms based on their edit distance. This means short words that are later in the alphabet will be visible first if matched fully. Example images at the bottom.

If the search box is emptied, the dictionary will resort alphabetically.

If the language changes, searching still works as intended both starting from an empty search and with a pre-existing search term.

If definition searching is set, searching still works as intended both starting from an empty search and with a pre-existing search term.

![image](https://user-images.githubusercontent.com/28300107/197216505-c1fc7206-6a67-430b-88ed-6b77dc60fec8.png)


There's a couple of TODOs I wanna throw in there. My sort functions are a bit silly, because they depend on having the original element present for fetching their IDs. The logic for fetching checkbox options is absolutely all over the place and I want to shrink it down into one function so it's consistent. But this is functional as-is, hooray!
