### PR TITLE
Focus search bar and fix width

### DIFF
--- a/css.css
+++ b/css.css
@@ -5,12 +5,17 @@
   src: url(https://raw.githubusercontent.com/lipu-linku/nasin-sitelen/main/sitelenselikiwenasuki.ttf);
 }
 
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
 body {
   font-family: "Noto Serif", Verdana, "Lucida Sans Unicode", sans-serif;
   text-align: center;
   background-color: var(--bg-color);
   color: var(--txt-color);
-  display: grid;
 }
 :root {
   --bg-color: #000000;
@@ -37,6 +42,7 @@ input {
   font-weight: bold;
   font-style: italic;
   width: 400px;
+  max-width: 100%;
   background-color: var(--bg-color);
   color: var(--highlight-color);
   padding: 0;
@@ -67,11 +73,9 @@ h2 {
   opacity: 0.5;
 }
 .page_width_limiter {
-  margin: auto;
+  margin: 0 auto;
+  padding: 0 10px;
   max-width: 840px;
-  width: -moz-available; /* WebKit-based browsers will ignore this. */
-  width: -webkit-fill-available; /* Mozilla-based browsers will ignore this. */
-  width: fill-available;
 }
 .entry {
   display: grid;

--- a/scripts.js
+++ b/scripts.js
@@ -372,6 +372,8 @@ function main() {
       document.body.classList.add("lightmode");
     } else document.body.classList.remove("lightmode");
   });
+
+  document.getElementById("searchbar").focus();
 }
 
 function build_select_option(option_value, text) {


### PR DESCRIPTION
1. Focus by default. This adds a statement at the end of `main` that selects the search bar then focuses it.
2. The width issue. The root cause of the issue was actually one line setting `display: grid` on the body element. Removing this fixed the horizontal scrolling problem on small screens. I also did a few CSS normalization things like removing margin and padding on html and body by default and instead apply the padding to the width limiter. Also AFAIK `width: fill-available` is unnecessary as the element is already a block element and block elements take the full width by default.