### PR TITLE
better mobile screen and other improvements

### DIFF
--- a/css.css
+++ b/css.css
@@ -5,6 +5,14 @@
   src: url(https://raw.githubusercontent.com/lipu-linku/nasin-sitelen/main/sitelenselikiwenasuki.ttf);
 }
 
+html {
+  color-scheme: dark;
+}
+
+html.lightmode {
+  color-scheme: light;
+}
+
 html,
 body {
   margin: 0;
@@ -42,33 +50,31 @@ body {
   outline-offset: 2px;
 }
 
-navbar {
-  display: grid;
-  grid-template-columns: 1fr minmax(60px, 400px) 1fr;
+nav {
+  display: flex;
+  justify-content: space-between;
   align-items: center;
   position: sticky;
-  padding: 0.5rem 0;
+  padding: 0.5rem 1rem;
   top: 0;
   z-index: 1;
-  width: 100%;
   background-color: var(--bg-color);
   border-bottom: 1px solid var(--border-color);
 }
 
-.navbar_segment {
+nav > div {
   display: flex;
-  flex-direction: row;
   align-items: center;
-  padding: 0 10px;
+  gap: 0.5rem;
 }
-.left {
-  justify-content: left;
+
+nav img {
+  width: 2rem;
+  height: 2rem;
+  display: block;
 }
-.right {
-  justify-content: right;
-}
-.navbar_segment > * {
-  margin: 0 5px;
+.lightmode nav img {
+  filter: invert(100%);
 }
 
 .searchbar {
@@ -86,21 +92,21 @@ navbar {
 }
 
 #language_selector {
-  font-size: 100%;
-  font-family: inherit;
-  background-color: var(--bg-color);
-  color: var(--txt-color);
   cursor: pointer;
-
-  width: 35px;
-  height: 35px;
-
   position: absolute;
-  bottom: 0;
+
+  top: 0;
   left: 0;
+  width: 100%;
+  height: 100%;
+
   opacity: 0;
 }
 
+#language_selector + img {
+  pointer-events: none;
+  border-radius: 100%;
+}
 #language_selector:focus + img {
   outline: 2px solid var(--highlight-color);
   outline-offset: 2px;
@@ -121,22 +127,49 @@ navbar {
   border-color: var(--highlight-color);
 }
 
+#normal_mode_button {
+  font: inherit;
+  color: inherit;
+  display: none;
+  background: var(--bg-alt-color);
+  border: 1px solid var(--border-color);
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
+}
+#normal_mode_button:hover {
+  background: var(--highlight-color);
+  border-color: var(--highlight-color);
+  color: var(--bg-color);
+}
+
+@media screen and (max-width: 600px) {
+  nav {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas: "logo" "buttons" "search";
+    gap: 0.5rem;
+    top: -3rem;
+  }
+
+  nav > .search_container {
+    grid-area: search;
+    grid-column: 1 / -1;
+  }
+
+  nav :last-child {
+    justify-content: end;
+  }
+}
+
 a {
   color: var(--link-color);
   text-decoration: none;
 }
 .navlink {
   display: block;
-  font-size: 100%;
-}
-navbar img {
-  width: 35px;
-  height: 35px;
-  display: block;
-  filter: none;
-}
-.lightmode navbar img {
-  filter: invert(100%);
+  margin-top: 1rem;
 }
 
 code {
@@ -160,7 +193,7 @@ h2 {
 }
 
 #dictionary {
-  margin-top: 0.5rem;
+  margin-top: 1rem;
 }
 
 .entry {
@@ -305,7 +338,5 @@ summary {
   flex-wrap: wrap;
   justify-content: center;
   gap: 1rem;
-}
-#normal_mode_button {
-  display: none;
+  margin-top: 1rem;
 }

--- a/css.css
+++ b/css.css
@@ -54,6 +54,7 @@ nav {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 1rem;
   position: sticky;
   padding: 0.5rem 1rem;
   top: 0;
@@ -63,9 +64,14 @@ nav {
 }
 
 nav > div {
+  flex: 1;
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+nav > :last-child {
+  justify-content: end;
 }
 
 nav img {
@@ -75,6 +81,12 @@ nav img {
 }
 .lightmode nav img {
   filter: invert(100%);
+}
+
+.search_container {
+  max-width: 20rem;
+  flex-basis: 100%;
+  flex-shrink: 0;
 }
 
 .searchbar {
@@ -144,7 +156,7 @@ nav img {
   color: var(--bg-color);
 }
 
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 640px) {
   nav {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -156,10 +168,7 @@ nav img {
   nav > .search_container {
     grid-area: search;
     grid-column: 1 / -1;
-  }
-
-  nav :last-child {
-    justify-content: end;
+    max-width: 100%;
   }
 }
 

--- a/css.css
+++ b/css.css
@@ -104,6 +104,10 @@ nav img {
 }
 
 #language_selector {
+  font: inherit;
+  background-color: var(--bg-color);
+  color: var(--txt-color);
+
   cursor: pointer;
   position: absolute;
 
@@ -146,6 +150,7 @@ nav img {
   background: var(--bg-alt-color);
   border: 1px solid var(--border-color);
   border-radius: 0.25rem;
+  margin: 0 auto;
   padding: 0.25rem 0.5rem;
   cursor: pointer;
   transition: background 0.2s, color 0.2s, border-color 0.2s;

--- a/css.css
+++ b/css.css
@@ -170,6 +170,10 @@ nav img {
     top: -3rem;
   }
 
+  nav > :first-child {
+    white-space: nowrap;
+  }
+
   nav > .search_container {
     grid-area: search;
     grid-column: 1 / -1;

--- a/index.html
+++ b/index.html
@@ -22,16 +22,21 @@
       content="interactive toki pona dictionary"
     />
     <meta property="og:url" content="https://linku.la/" />
+
+    <script>
+      if (localStorage.checkbox_lightmode === "true") {
+        document.documentElement.classList.add("lightmode");
+      }
+    </script>
   </head>
   <body onload="main()">
-    <navbar class="search_container">
-      <div class="navbar_segment left">
-        <span class="navlink">
-          <img src="icon.png" alt="lipu Linku">
-        </span>
-        <span class="navlink">lipu Linku</span>
+    <nav>
+      <div class="logo">
+        <img src="icon.png" alt="lipu Linku" />
+        lipu Linku
       </div>
-      <div>
+
+      <div class="search_container">
         <input
           id="searchbar"
           class="searchbar main_input"
@@ -43,23 +48,25 @@
           spellcheck="false"
         />
         <button id="normal_mode_button" onclick="normal_mode()">
-          Back to dictionary
+          Back to Dictionary
         </button>
       </div>
-      <div class="navbar_segment right">
-        <div id="language_selector_wrapper">
+
+      <div>
+        <label id="language_selector_wrapper" title="Select Language">
           <select
             id="language_selector"
             class="main_input"
             onchange="language_select_changed(this)"
           ></select>
-          <img src="world.png" alt="Select language">
-        </div>
-        <a class="navlink" href="about">
-          <img src="ijo-a.png" alt="About Linku">
+          <img src="world.png" alt="Select language" />
+        </label>
+        <a href="about" title="About Linku">
+          <img src="ijo-a.png" alt="About Linku" />
         </a>
       </div>
-    </navbar>
+    </nav>
+
     <div class="page_width_limiter">
       <div id="checkbox_container">
         <div id="usage_selector"></div>

--- a/scripts.js
+++ b/scripts.js
@@ -365,15 +365,11 @@ function main() {
   search_changed(document.getElementById("searchbar"));
 
   let checkbox_lightmode = document.getElementById("checkbox_lightmode");
-  checkbox_lightmode.checked = localStorage.checkbox_lightmode === "true";
-  if (checkbox_lightmode.checked) {
-    document.body.classList.add("lightmode");
-  }
   checkbox_lightmode.addEventListener("change", function (e) {
     localStorage.checkbox_lightmode = e.target.checked;
     if (e.target.checked) {
-      document.body.classList.add("lightmode");
-    } else document.body.classList.remove("lightmode");
+      document.documentElement.classList.add("lightmode");
+    } else document.documentElement.classList.remove("lightmode");
   });
 
   document.getElementById("searchbar").focus();


### PR DESCRIPTION
# summary of changes

1. fixes lightmode so that there is no flash of dark content by placing an inline script in the head that runs before full page rendering
2. simplifies the markdown and the styles a little bit for the navbar, not really important
3. makes the "back to dictionary" button look nicer
4. adds a dynamic `color-scheme: dark` or `light` so that the scrollbar looks nicer on chrome and firefox in dark mode
5. changes the navbar so that only on small screens, the search bar appears under the logo and the navigation buttons so it can be wider. i tested this on my phone and it looks like this

https://user-images.githubusercontent.com/27079662/213830257-91b09245-da5e-4cf6-bb0a-b610c88845e4.mp4
