### PR TITLE
Fix single word mode visibility

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -192,6 +192,10 @@ function update_visibility(search_term) {
 function fill_dictionary() {
   let dictionary = document.getElementById("dictionary");
   if (show_word) {
+    if (!(show_word in data)) {
+      alert("Couldn't find word '" + show_word + "'!");
+    }
+
     dictionary.appendChild(build_word(show_word, data[show_word]));
     return;
   } else {

--- a/scripts.js
+++ b/scripts.js
@@ -142,6 +142,10 @@ function set_visibility(elem, display) {
 }
 
 function find_vis_state(search_term, id, word_elem) {
+  if (show_word === id) {
+    return "";
+  }
+
   let usage_cat_set = localStorage.getItem(
     usages_to_checkboxes[data[id]["usage_category"]]
   );
@@ -368,8 +372,7 @@ function build_word(id, word) {
 }
 
 function main() {
-  let show_single_word = urlParams.get("q");
-  if (show_single_word) {
+  if (urlParams.get("q")) {
     single_word_mode();
   }
   // Select language
@@ -382,11 +385,6 @@ function main() {
   // show based on settings
   search_changed(document.getElementById("searchbar"));
   document.getElementById("searchbar").focus();
-
-  if (show_single_word) {
-    // HACK: we just override the vis of the one word
-    document.getElementById(show_single_word).style.display = "";
-  }
 }
 
 function build_select_option(option_value, text) {

--- a/scripts.js
+++ b/scripts.js
@@ -368,7 +368,8 @@ function build_word(id, word) {
 }
 
 function main() {
-  if (urlParams.get("q")) {
+  let show_single_word = urlParams.get("q");
+  if (show_single_word) {
     single_word_mode();
   }
   // Select language
@@ -377,9 +378,15 @@ function main() {
   checkbox_select_default();
   // Generate words
   fill_dictionary();
+
   // show based on settings
   search_changed(document.getElementById("searchbar"));
   document.getElementById("searchbar").focus();
+
+  if (show_single_word) {
+    // HACK: we just override the vis of the one word
+    document.getElementById(show_single_word).style.display = "";
+  }
 }
 
 function build_select_option(option_value, text) {
@@ -541,6 +548,9 @@ function single_word_mode() {
   }
   document.getElementById("searchbar").style.display = "none";
   document.getElementById("normal_mode_button").style.display = "initial";
+  // console.log(show_word);
+  // document.getElementById();
+  // document.getElementById(show_word).style.display = "";
 }
 function normal_mode() {
   window.location.search = ""; // remove query and refresh


### PR DESCRIPTION
Single words were not showing up if the user's usage categories didn't match. Looks to have been caused by the definition search fallback from before. We call `search_changed` after setting up single word mode even though there's only one word in the dictionary div. Wack.

Bonus feature: Alerts for if your word doesn't exist in single word mode.